### PR TITLE
Added `ExcludeHardwareId` parameter for `Get-WindowsUpdate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ if ($updates) {
     }
 }
 ```
-# If you want to exclude KBIDs
+# If you want to exclude KBIDs and updates for specific hardware ID's
 
 ```powershell
 Import-Module WindowsUpdates
 
-$updates = Get-WindowsUpdate -Verbose -ExcludeKBId @("KB2267602")
+$updates = Get-WindowsUpdate -Verbose -ExcludeKBId @("KB2267602") -ExcludeHardwareId @("{084f01fa-e634-4d77-83ee-074817c03581}")
 ```
 
 ## Compatibility

--- a/WindowsUpdates/WindowsUpdates.psm1
+++ b/WindowsUpdates/WindowsUpdates.psm1
@@ -93,7 +93,9 @@ function Get-WindowsUpdate {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$false)]
-        [array]$ExcludeKBId=@()
+        [array]$ExcludeKBId=@(),
+        [Parameter(Mandatory=$false)]
+        [array]$ExcludeHardwareId=@()
     )
     PROCESS {
         $updateSearcher = Get-UpdateSearcher
@@ -108,13 +110,14 @@ function Get-WindowsUpdate {
         }
         $updates = $updateResult.Updates
         $filteredUpdates = New-Object -ComObject $UPDATE_COLL_COM_CLASS
-
         for ($i=0; $i -lt $updates.Count; $i++) {
             $update = $updates.Item($i)
             $updateKBId = ($update.KBArticleIDs -join ", KB")
             if ($ExcludeKBId -contains ("KB" + $updateKBId)) {
                 Write-Verbose ("Exclude update KB{0}" `
                     -f @($updateKBId))
+            } elseif ($ExcludeHardwareId -contains $update.DriverHardwareID) {
+                Write-Verbose ("Exclude update: {0}" -f @($Title))
             } else {
                 Add-WindowsUpdateToCollection $filteredUpdates $update
             }


### PR DESCRIPTION
This PR fixes the issue regarding the updates for Windows 10 Enterprise version.
Issue report here: https://github.com/cloudbase/WindowsUpdateCLI/issues/1